### PR TITLE
corrected typo in ubuntu.yaml that breaks holdback repo

### DIFF
--- a/contrib/fuel_mirror/data/ubuntu.yaml
+++ b/contrib/fuel_mirror/data/ubuntu.yaml
@@ -62,7 +62,7 @@ repos:
     -   &mos_holdback
         name: "mos-holdback"
         uri: *mos_baseurl
-        suite: "mos$mos_version"
+        suite: "mos$mos_version-holdback"
         section: "main restricted"
         type: "deb"
         priority: 1000


### PR DESCRIPTION
Took me awhile to track this down...

This typo causes fuel-mirror to break the holdback repository and caused me grief in getting the ubuntu_bootstrap image built.